### PR TITLE
Update rocSOLVER-9999.ebuild

### DIFF
--- a/sci-libs/rocSOLVER/rocSOLVER-9999.ebuild
+++ b/sci-libs/rocSOLVER/rocSOLVER-9999.ebuild
@@ -23,6 +23,7 @@ RDEPEND=""
 DEPEND="${RDEPEND}
 	dev-util/cmake
 	sys-devel/hcc
+	sys-devel/hip
 	>=dev-util/ninja-1.9.0"
 
 src_prepare() {


### PR DESCRIPTION
add hip as a build dependency, steps to reproduce

emerge -C sys-devel/hip
emerge -1 sci-libs/rocSOLVER

should result in the following build error:

CMake Error at CMakeLists.txt:166 (find_package):
  Could not find a package configuration file provided by "hip" with any of
  the following names:

    hipConfig.cmake
    hip-config.cmake