### PR TITLE
Fix strict LLVM version requirement in Tensile

### DIFF
--- a/sci-libs/rocBLAS/rocBLAS-2.10.0.ebuild
+++ b/sci-libs/rocBLAS/rocBLAS-2.10.0.ebuild
@@ -54,6 +54,8 @@ src_prepare() {
 	eapply "${FILESDIR}/Tensile-2.8-add_HIP_include_path.patch"
 
 	sed -e "s:const Items empty:const Items empty = {}:" -i Tensile/Source/lib/include/Tensile/EmbeddedData.hpp || die
+	# Eliminate requirement of LLVM version 7.0 - there is already a patch on github
+	sed -e "s:find_package(LLVM 7.0:find_package(LLVM:" -i Tensile/Source/lib/CMakeLists.txt || die
 
 	sed -e "s: PREFIX rocblas:# PREFIX rocblas:" -i ${S}/library/src/CMakeLists.txt || die
 	sed -e "s:<INSTALL_INTERFACE\:include:<INSTALL_INTERFACE\:include/rocblas:" -i ${S}/library/src/CMakeLists.txt || die


### PR DESCRIPTION
Don't require exact version 7.0 of LLVM in one of Tensile `CMakeLists.txt`'s in rocBLAS to fix the building failure on systems without LLVM-7.0 exactly (7.x branch also wouldn't work). This fix is actually already [there](https://github.com/ROCmSoftwarePlatform/Tensile/commit/f150cf39f76038d250ac20ee813d12abf38d2205) in Tensile repository, but after the rocm-2.10 tag, so backporting this way.