### PR TITLE
Default destination for rocThrust header files

### DIFF
--- a/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
@@ -25,9 +25,9 @@ src_prepare() {
 	eapply "${FILESDIR}/rocThrust-2.7-disable-rocPRIM-download.patch"
 
 	sed -e "s: PREFIX rocthrust:# PREFIX rocthrust:" -i ${S}/thrust/CMakeLists.txt
-	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION \$\{CMAKE_INSTALL_FULL_INCLUDEDIR\}/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
-	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:\$\{CMAKE_INSTALL_INCLUDEDIR\}:" -i ${S}/thrust/CMakeLists.txt
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 

--- a/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
@@ -25,9 +25,9 @@ src_prepare() {
 	eapply "${FILESDIR}/rocThrust-2.7-disable-rocPRIM-download.patch"
 
 	sed -e "s: PREFIX rocthrust:# PREFIX rocthrust:" -i ${S}/thrust/CMakeLists.txt
-	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION \$\{CMAKE_INSTALL_FULL_INCLUDEDIR\}/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
-	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:\$\{CMAKE_INSTALL_INCLUDEDIR\}:" -i ${S}/thrust/CMakeLists.txt
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 


### PR DESCRIPTION
I'm working at an ebuild for PyTorch with ROCm support now (https://github.com/aclex/pytorch-ebuild), which is planned to use your ROCm infrastructure. PyTorch uses CMake to find ROCm parts (well, in theory, there're already a couple of issues I've found) and I've found some build errors related to rocThrust. As I understand, they are because of CMake config file of rocThrust reports wrong include directories.

And one question, that have crossed my mind during these experiments, is: is there any particular reason behind we can't install rocThrust header files in the system-wide (i.e. like `/usr/include`) path? It is apparently header-only library and all its header files are contained in `thrust` directory, so this is the only thing to be actually installed to `/usr/include`. I mean, it's certainly just a proposal, but maybe you'd be able to look at this request.

As for alternative methods, I'm afraid, there's no good one: the inconsistency in CMake files to be installed (namely, `usr/lib/cmake/rocthrust/rocthrust-config.cmake`) is quite hard to fix gently, as it is created by `rocm_export_targets_header_only()` CMake function (in `cmake/ROCMExportTargetsHeaderOnly.cmake` of rocThrust) and just concatenates optional `PREFIX` with `CMAKE_INSTALL_INCLUDEDIR` (which is like `include`). So to support current installation path (`include/rocthrust`) it should be changed significantly.