### PR TITLE
rocThrust: fix filling up of `_INCLUDE_DIR(S)` CMake variables

### DIFF
--- a/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 

--- a/sci-libs/rocThrust/rocThrust-2.7.0-r1.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.7.0-r1.ebuild
@@ -27,6 +27,7 @@ src_prepare() {
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 

--- a/sci-libs/rocThrust/rocThrust-2.7.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.7.0.ebuild
@@ -27,6 +27,7 @@ src_prepare() {
 	sed -e "s: PREFIX rocthrust:# PREFIX rocthrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare 

--- a/sci-libs/rocThrust/rocThrust-2.8.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.8.0.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 

--- a/sci-libs/rocThrust/rocThrust-2.9.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.9.0.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 

--- a/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust/thrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
+	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
 


### PR DESCRIPTION
Continuation of #112.

In this fix the destination for the header files in the subdirectory of the system include path is prevented, and all its definitions in the output CMake files are corrected (to something like
`/usr/include/rocthrust`). As previously, it's captured by PyTorch successfully (with proper environment variables set).

The fix itself is quite in-place-ful, I've been thinking over doing it the proper way, but as the main line of the upstream is to install everything to `/opt/rocm`, it might be suboptimal. Still, I think, I'll try to send a pull request to upstream for maybe support proper installation in case of optional system-wide way.