### PR TITLE
Don't specify `CMAKE_INSTALL_PREFIX` in rocRAND

### DIFF
--- a/sci-libs/rocRAND/rocRAND-2.10.0.ebuild
+++ b/sci-libs/rocRAND/rocRAND-2.10.0.ebuild
@@ -50,7 +50,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX="/usr"
 	)
 
 	cmake-utils_src_configure

--- a/sci-libs/rocRAND/rocRAND-2.6.0.ebuild
+++ b/sci-libs/rocRAND/rocRAND-2.6.0.ebuild
@@ -51,7 +51,7 @@ src_configure() {
 	export HIP_DIR=/usr/lib/hip/$(ver_cut 1-2)/lib/cmake/
 	export CXX=/usr/lib/hcc/$(ver_cut 1-2)/bin/hcc
 
-	cmake -DHIP_PLATFORM=hcc -DHIP_ROOT_DIR=/usr/lib/hip/$(ver_cut 1-2)/ -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX="/usr/" ${S}
+	cmake -DHIP_PLATFORM=hcc -DHIP_ROOT_DIR=/usr/lib/hip/$(ver_cut 1-2)/ -DBUILD_TEST=OFF ${S}
 }
 
 src_compile() {

--- a/sci-libs/rocRAND/rocRAND-2.7.0-r1.ebuild
+++ b/sci-libs/rocRAND/rocRAND-2.7.0-r1.ebuild
@@ -57,7 +57,6 @@ src_configure() {
 		-DHIP_PLATFORM=hcc
 		-DHIP_ROOT_DIR=/usr/lib/hip
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX="/usr"
 		-DCMAKE_CXX_FLAGS:STRING="-I${HCC_ROOT}/include"
 	)
 

--- a/sci-libs/rocRAND/rocRAND-2.7.0.ebuild
+++ b/sci-libs/rocRAND/rocRAND-2.7.0.ebuild
@@ -56,7 +56,7 @@ src_configure() {
 #		-DCMAKE_INSTALL_PREFIX="/usr/lib/"
 #	)
 
-	cmake -DHIP_PLATFORM=hcc -DHIP_ROOT_DIR=/usr/lib/hip/$(ver_cut 1-2)/ -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX="/usr/" ${S}
+	cmake -DHIP_PLATFORM=hcc -DHIP_ROOT_DIR=/usr/lib/hip/$(ver_cut 1-2)/ -DBUILD_TEST=OFF ${S}
 #	cmake-utils_src_configure
 }
 

--- a/sci-libs/rocRAND/rocRAND-2.8.0.ebuild
+++ b/sci-libs/rocRAND/rocRAND-2.8.0.ebuild
@@ -55,7 +55,6 @@ src_configure() {
 		-DHIP_PLATFORM=hcc
 		-DHIP_ROOT_DIR=/usr/lib/hip
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX="/usr"
 		-DCMAKE_CXX_FLAGS:STRING="-I${HCC_ROOT}/include"
 	)
 

--- a/sci-libs/rocRAND/rocRAND-2.9.0.ebuild
+++ b/sci-libs/rocRAND/rocRAND-2.9.0.ebuild
@@ -50,7 +50,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX="/usr"
 	)
 
 	cmake-utils_src_configure

--- a/sci-libs/rocRAND/rocRAND-3.0.0.ebuild
+++ b/sci-libs/rocRAND/rocRAND-3.0.0.ebuild
@@ -50,7 +50,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX="/usr"
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
It is apparently added by `cmake-utils` eclass automatically, so no reason to. But pretty much cosmetic thing noticed again.