### PR TITLE
Use CMake variable for `lib` path in rocThrust

### DIFF
--- a/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
@@ -29,8 +29,7 @@ src_prepare() {
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
-
-	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
+	sed -e "s:\${ROCM_INSTALL_LIBDIR}:\${CMAKE_INSTALL_LIBDIR}:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare

--- a/sci-libs/rocThrust/rocThrust-2.7.0-r1.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.7.0-r1.ebuild
@@ -28,8 +28,7 @@ src_prepare() {
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
-
-	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
+	sed -e "s:\${ROCM_INSTALL_LIBDIR}:\${CMAKE_INSTALL_LIBDIR}:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare

--- a/sci-libs/rocThrust/rocThrust-2.7.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.7.0.ebuild
@@ -28,6 +28,7 @@ src_prepare() {
 	sed -e "s:  DESTINATION rocthrust/include/thrust:  DESTINATION include/rocthrust:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
+	sed -e "s:\${ROCM_INSTALL_LIBDIR}:\${CMAKE_INSTALL_LIBDIR}:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare 

--- a/sci-libs/rocThrust/rocThrust-2.8.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.8.0.ebuild
@@ -29,8 +29,7 @@ src_prepare() {
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
-
-	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
+	sed -e "s:\${ROCM_INSTALL_LIBDIR}:\${CMAKE_INSTALL_LIBDIR}:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare

--- a/sci-libs/rocThrust/rocThrust-2.9.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.9.0.ebuild
@@ -29,8 +29,7 @@ src_prepare() {
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
-
-	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
+	sed -e "s:\${ROCM_INSTALL_LIBDIR}:\${CMAKE_INSTALL_LIBDIR}:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare

--- a/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
@@ -29,8 +29,7 @@ src_prepare() {
 	sed -e "s:rocm_install_symlink_subdir(rocthrust):#rocm_install_symlink_subdir(rocthrust):" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:<INSTALL_INTERFACE\:rocthrust/include/:<INSTALL_INTERFACE\:include/rocthrust/:" -i ${S}/thrust/CMakeLists.txt
 	sed -e "s:\${CMAKE_INSTALL_INCLUDEDIR}:&/rocthrust:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
-
-	# TODO: install cmake files to "/usr/lib64/cmake" instead of "/usr/lib/cmake"?
+	sed -e "s:\${ROCM_INSTALL_LIBDIR}:\${CMAKE_INSTALL_LIBDIR}:" -i ${S}/cmake/ROCMExportTargetsHeaderOnly.cmake
 
 	eapply_user
 	cmake-utils_src_prepare


### PR DESCRIPTION
To avoid confusion of `lib`/`lib64` and make CMake define default library path itself. This time it seems change the destination for output CMake files.