### PR TITLE
Don't specify `CMAKE_INSTALL_PREFIX` for rocThrust

### DIFF
--- a/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.10.0.ebuild
@@ -46,7 +46,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX=/usr/
 	)
 
 	cmake-utils_src_configure

--- a/sci-libs/rocThrust/rocThrust-2.6.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.6.0.ebuild
@@ -44,7 +44,7 @@ src_configure() {
 	export HIP_DIR=/usr/lib/hip/$(ver_cut 1-2)/lib/cmake/
 	export CXX=/usr/lib/hcc/$(ver_cut 1-2)/bin/hcc
 
-	cmake -DHIP_PLATFORM=hcc -DHIP_ROOT_DIR=/usr/lib/hip/$(ver_cut 1-2)/ -DBUILD_TEST=OFF -DCMAKE_INSTALL_PREFIX=/usr/ ${S}
+	cmake -DHIP_PLATFORM=hcc -DHIP_ROOT_DIR=/usr/lib/hip/$(ver_cut 1-2)/ -DBUILD_TEST=OFF ${S}
 }
 
 src_compile() {

--- a/sci-libs/rocThrust/rocThrust-2.7.0-r1.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.7.0-r1.ebuild
@@ -43,7 +43,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX=/usr/
 	)
 
 	cmake-utils_src_configure

--- a/sci-libs/rocThrust/rocThrust-2.7.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.7.0.ebuild
@@ -41,7 +41,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX=/usr/
 	)
 	
 	cmake-utils_src_configure 

--- a/sci-libs/rocThrust/rocThrust-2.8.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.8.0.ebuild
@@ -44,7 +44,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX=/usr/
 	)
 
 	cmake-utils_src_configure

--- a/sci-libs/rocThrust/rocThrust-2.9.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-2.9.0.ebuild
@@ -46,7 +46,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX=/usr/
 	)
 
 	cmake-utils_src_configure

--- a/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
+++ b/sci-libs/rocThrust/rocThrust-3.0.0.ebuild
@@ -46,7 +46,6 @@ src_configure() {
 	local mycmakeargs=(
 		-DHIP_PLATFORM=hcc
 		-DBUILD_TEST=OFF
-		-DCMAKE_INSTALL_PREFIX=/usr/
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
Optionally remove it here, as well, as It's apparently added by `cmake-utils` eclass automatically.