### PR TITLE
Hotfix to not allow HIP capture its version from system

### DIFF
--- a/sys-devel/hip/hip-3.0.0.ebuild
+++ b/sys-devel/hip/hip-3.0.0.ebuild
@@ -81,6 +81,8 @@ src_configure() {
 		)
 	fi
 
+	local HIP_PATH=""
+
 	cmake-utils_src_configure
 }
 


### PR DESCRIPTION
This is apparently additional measure to fix the problem, as the root cause of it is in the version mechanism of the upstream (to be reported).

The mechanism of the problem looks like the following. CMake in HIP gets package version using `hipconfig` utility (Perl script) bundled in the distribution. The main function of the utility is to be installed in the system and report technical information about the installed HIP instance, including version. It uses `HIP_PATH` environment variable to locate the necessary files. In the absence of this variable or files it reports the version hard-coded in the utility itself. The latter is used by CMake to detect the package version.

In case of installed HIP instance already exists in the system and `HIP_PATH` variable is set properly, `hipconfig` utility from the distribution, executed by CMake, luckily finds all the necessary files and reports version of the system version, rather than package, hard-coded, one. As a result, the binaries are built properly, but report wrong version about themselves, which renders the whole stack unusable.