### PR TITLE
Resolve CppHeaderParser build dependency of roctracer

### DIFF
--- a/dev-python/CppHeaderParser/CppHeaderParser-2.7.4.ebuild
+++ b/dev-python/CppHeaderParser/CppHeaderParser-2.7.4.ebuild
@@ -1,0 +1,21 @@
+# Copyright 1999-2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+PYTHON_COMPAT=( python2_7 python3_{5,6,7} pypy{,3} )
+
+inherit distutils-r1
+
+DESCRIPTION="Parse C++ header files and generate a data structure"
+HOMEPAGE="http://senexcanis.com/open-source/cppheaderparser/"
+SRC_URI="mirror://pypi/${PN:0:1}/${PN}/${P}.tar.gz"
+
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~mips ~ppc ~ppc64 ~s390 ~sparc ~x86 ~amd64-linux ~x86-linux ~x64-solaris"
+
+RDEPEND="dev-python/ply"
+
+DEPEND="
+	${RDEPEND}
+	dev-python/setuptools"

--- a/dev-util/roctracer/roctracer-3.0.0.ebuild
+++ b/dev-util/roctracer/roctracer-3.0.0.ebuild
@@ -17,6 +17,7 @@ RDEPEND="dev-libs/rocr-runtime
 	 sys-devel/hip"
 DEPEND="dev-util/cmake
 	dev-lang/python:2.7
+	dev-python/CppHeaderParser
 	${RDEPEND}"
 
 src_unpack() {


### PR DESCRIPTION
I've tried to build `dev-util/roctracer` (it is needed in fresh PyTorch-1.4.0, which I'm experimenting with), and it fails to build without `CppHeaderParser` Python package. The following error message is printed during configuration:
```cmake
Traceback (most recent call last):
  File "/var/tmp/portage/dev-util/roctracer-3.0.0/work/roctracer-3.0.0/script/gen_ostream_ops.py", line 4, in <module>
    import CppHeaderParser
ModuleNotFoundError: No module named 'CppHeaderParser'
```
And subsequently it fails in compilation with several messages like this:
```bash
In file included from /var/tmp/portage/dev-util/roctracer-3.0.0/work/roctracer-3.0.0/src/core/roctracer.cpp:30:
/var/tmp/portage/dev-util/roctracer-3.0.0/work/roctracer-3.0.0/inc/roctracer_kfd.h:30:10: fatal error: inc/kfd_ostream_ops.h: No such file or directory
   30 | #include "inc/kfd_ostream_ops.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [CMakeFiles/roctracer64.dir/build.make:66: CMakeFiles/roctracer64.dir/src/core/roctracer.cpp.o] Error 1
make[2]: Leaving directory '/var/tmp/portage/dev-util/roctracer-3.0.0/work/build'
make[1]: *** [CMakeFiles/Makefile2:150: CMakeFiles/roctracer64.dir/all] Error 2
make[1]: Leaving directory '/var/tmp/portage/dev-util/roctracer-3.0.0/work/build'
make: *** [Makefile:155: all] Error 2
```
So I've added an ebuild for `CppHeaderParser` and a dependency on it to `roctracer` ebuild. It seems to help.